### PR TITLE
added authToken query param support

### DIFF
--- a/dash/dash-renderer/src/AppContainer.react.js
+++ b/dash/dash-renderer/src/AppContainer.react.js
@@ -53,11 +53,19 @@ class UnconnectedAppContainer extends React.Component {
     }
 
     render() {
-        const {config} = this.props;
+        const {config, dispatch} = this.props;
         if (type(config) === 'Null') {
             return <div className='_dash-loading'>Loading...</div>;
         }
         const {show_undo_redo} = config;
+
+        const urlParams = new URLSearchParams(window.location.search);
+        const authToken = urlParams.get('authToken');
+        if (authToken) {
+            config.fetch.headers['Authorization'] = `Bearer ${authToken}`;
+            dispatch(setConfig(config));
+        }
+
         return (
             <React.Fragment>
                 {show_undo_redo ? <Toolbar /> : null}


### PR DESCRIPTION
This MR
- Adds support for passing an query param like ```?authToken=...``` to the dash app landing page
- This auth token is then used as the auth header for all requests made by the dash app
- This ensures that all paths like ```/public/notebooks/{notebook-server-id}/app/...``` are authenticated and allows for a dash app to be run in a singlestore notebook server